### PR TITLE
ci: harden master with CODEOWNERS and unconditional lint-workflows trigger

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# CI/CD configuration changes require admin review
+# Background: https://github.com/Abblix/Docs/blob/master/wiki/github-repository-security-setup.md
+.github/workflows/  @kirill-abblix
+.github/scripts/    @kirill-abblix

--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -6,10 +6,7 @@ on:
       - '.github/workflows/**'
       - '.github/scripts/lint-no-inline-secrets.py'
   push:
-    branches: [master]
-    paths:
-      - '.github/workflows/**'
-      - '.github/scripts/lint-no-inline-secrets.py'
+    branches: [master, develop]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Two commits land together so the new lint trigger satisfies the ruleset's required-status-checks rule on master.

- chore(security): add CODEOWNERS for CI/CD configuration paths
- ci: trigger lint-workflows on every push to master/develop

Pushing these directly to master got rejected (GH013) because the pre-existing paths-filter on the lint workflow meant the CODEOWNERS commit alone never triggered a lint run, leaving the required check in 'expected' state forever.