### PR TITLE
ci: bump actions/setup-python to v6.2.0 (Node 24 support)

### DIFF
--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.5.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
GitHub deprecates Node.js 20 actions on June 2nd, 2026. setup-python v5.6.0 runs on Node 20; v6.2.0 supports Node 24. SHA pinned per security baseline.