### PR TITLE
ci(lint-workflows): hash-pin pip install to close Sonar S8541/S8544

### DIFF
--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -31,8 +31,15 @@ jobs:
         with:
           python-version: '3.12'
 
+      # --only-binary :all: skips arbitrary setup-script execution at install
+      # time (closes Sonar S8541). --require-hashes + pinned requirements file
+      # locks both the resolved version and the artifact bytes — a malicious
+      # PyPI release with the same version cannot pass the hash check (closes
+      # Sonar S8544).
       - name: Install PyYAML
-        run: pip install --disable-pip-version-check pyyaml
+        run: |
+          pip install --disable-pip-version-check --only-binary :all: \
+            --require-hashes -r .github/workflows/requirements/lint-workflows.txt
 
       - name: "Block inline untrusted-input interpolation in run: blocks"
         run: python .github/scripts/lint-no-inline-secrets.py

--- a/.github/workflows/requirements/lint-workflows.txt
+++ b/.github/workflows/requirements/lint-workflows.txt
@@ -1,0 +1,11 @@
+# Pinned dependency for the lint-workflows GitHub Actions job.
+# Hashes are for the exact wheels resolved on the runner (ubuntu-latest +
+# Python 3.12). x86_64 is the canonical runner image; aarch64 included so a
+# future runner-class switch does not break CI silently.
+#
+# Bumping: rerun `pip download --only-binary :all: --no-deps pyyaml==<v> -d /tmp/`,
+# read sha256 of each .whl, replace below.
+
+pyyaml==6.0.2 \
+    --hash=sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476 \
+    --hash=sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ out/
 # Ignore JetBrains project files
 .idea/
 *.cmd
+
+# Local AI/dev guidance — kept untracked, mirrors policy in Docs/AuthSvc/Oidc.Server
+**/CLAUDE.md


### PR DESCRIPTION
Mirrors Abblix/Oidc.Server#70 — same pip-install line, same fix.

PyYAML moved to `.github/workflows/requirements/lint-workflows.txt` with `==6.0.2` + sha256 hashes (x86_64 + aarch64).

Rule codified in [Docs/wiki/github-actions-security-checklist.md](https://github.com/Abblix/Docs/blob/master/wiki/github-actions-security-checklist.md) (Cache and runner integrity).

Test plan:
- [x] `actionlint` clean.
- [ ] CI lint-workflows runs on this PR.