### PR TITLE
ci: cap GHA timeouts (job <=5m, step <=3m)

### DIFF
--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           persist-credentials: false
 
+        timeout-minutes: 3
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
@@ -36,14 +37,18 @@ jobs:
       # locks both the resolved version and the artifact bytes — a malicious
       # PyPI release with the same version cannot pass the hash check (closes
       # Sonar S8544).
+        timeout-minutes: 3
       - name: Install PyYAML
         run: |
           pip install --disable-pip-version-check --only-binary :all: \
             --require-hashes -r .github/workflows/requirements/lint-workflows.txt
 
+        timeout-minutes: 3
       - name: "Block inline untrusted-input interpolation in run: blocks"
         run: python .github/scripts/lint-no-inline-secrets.py
 
+        timeout-minutes: 3
+    timeout-minutes: 5
   actionlint:
     name: actionlint (schema + shellcheck)
     runs-on: ubuntu-latest
@@ -56,6 +61,7 @@ jobs:
         with:
           persist-credentials: false
 
+        timeout-minutes: 3
       - name: Install actionlint
         run: |
           curl -fsSL -o actionlint.tar.gz \
@@ -63,5 +69,8 @@ jobs:
           tar -xzf actionlint.tar.gz actionlint
           chmod +x actionlint
 
+        timeout-minutes: 3
       - name: Run actionlint
         run: ./actionlint -color
+        timeout-minutes: 3
+    timeout-minutes: 5


### PR DESCRIPTION
## Summary
- Apply Abblix billing-protection policy: `timeout-minutes: 5` on jobs, `3` on steps.
- Affirm `concurrency.cancel-in-progress: true` (already present).

## Context
May 2026 GHA usage hit the org limit. 5m/3m caps are intentionally tight; known-long jobs may need deliberate lift after CI resumes.

## Test plan
- [ ] actionlint check passes
- [ ] Untrusted-input interpolation check passes
- [ ] Merge after CI resumes in June (currently billing-frozen)