### PR TITLE
Bump Abblix packages to v2.3 and add BlazorSample

### DIFF
--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -1,11 +1,10 @@
 name: Lint workflows
 
 on:
+  # No paths filter on pull_request: both jobs are required status checks on
+  # master, and a path-filtered required check never reports on out-of-scope
+  # PRs, leaving them permanently unmergeable. The jobs cost ~1 minute per PR.
   pull_request:
-    paths:
-      - '.github/workflows/**'
-      - '.github/scripts/lint-no-inline-secrets.py'
-      - '.github/codeql/**'
   push:
     branches: [master, develop]
   workflow_dispatch:

--- a/BlazorSample/BlazorSample.csproj
+++ b/BlazorSample/BlazorSample.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/BlazorSample/Components/App.razor
+++ b/BlazorSample/Components/App.razor
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <title>Blazor OIDC client for Abblix OIDC Server</title>
+    <HeadOutlet />
+</head>
+<body>
+    <Routes />
+    <script src="_framework/blazor.web.js"></script>
+</body>
+</html>

--- a/BlazorSample/Components/Layout/MainLayout.razor
+++ b/BlazorSample/Components/Layout/MainLayout.razor
@@ -1,0 +1,5 @@
+@inherits LayoutComponentBase
+
+<main style="max-width: 48rem; margin: 2rem auto; padding: 0 1rem; font-family: system-ui, sans-serif;">
+    @Body
+</main>

--- a/BlazorSample/Components/Pages/Error.razor
+++ b/BlazorSample/Components/Pages/Error.razor
@@ -1,0 +1,6 @@
+@page "/Error"
+
+<PageTitle>Error</PageTitle>
+
+<h1>Something went wrong</h1>
+<p>An error occurred while processing your request.</p>

--- a/BlazorSample/Components/Pages/Home.razor
+++ b/BlazorSample/Components/Pages/Home.razor
@@ -1,0 +1,27 @@
+@page "/"
+
+<PageTitle>Blazor OIDC client</PageTitle>
+
+<h1>Blazor client for Abblix OIDC Server</h1>
+
+<AuthorizeView>
+    <Authorized>
+        <p>Signed in as <strong>@context.User.Identity?.Name</strong>.</p>
+
+        <h2>Claims</h2>
+        <ul>
+            @foreach (var claim in context.User.Claims)
+            {
+                <li>@claim.Type: @claim.Value</li>
+            }
+        </ul>
+
+        @* data-enhance-nav="false" forces a real browser navigation so the redirect that
+           clears the cookie is followed by the browser, not by enhanced navigation. *@
+        <p><a href="/auth/logout" data-enhance-nav="false">Sign out</a></p>
+    </Authorized>
+    <NotAuthorized>
+        <p>You are not signed in.</p>
+        <p><a href="/auth/login" data-enhance-nav="false">Sign in</a></p>
+    </NotAuthorized>
+</AuthorizeView>

--- a/BlazorSample/Components/Routes.razor
+++ b/BlazorSample/Components/Routes.razor
@@ -1,0 +1,6 @@
+<Router AppAssembly="typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+</Router>

--- a/BlazorSample/Components/_Imports.razor
+++ b/BlazorSample/Components/_Imports.razor
@@ -1,0 +1,9 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using BlazorSample
+@using BlazorSample.Components
+@using BlazorSample.Components.Layout

--- a/BlazorSample/Program.cs
+++ b/BlazorSample/Program.cs
@@ -1,0 +1,66 @@
+using BlazorSample.Components;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+
+var builder = WebApplication.CreateBuilder(args);
+var configuration = builder.Configuration;
+
+// Razor components rendered with the interactive Server render mode.
+builder.Services
+    .AddRazorComponents()
+    .AddInteractiveServerComponents();
+
+// OIDC client wiring: a local cookie holds the session, OpenID Connect drives the login.
+// The same shape as TestClientApp, bound from appsettings so secrets stay out of code.
+builder.Services
+    .AddAuthentication(options => configuration.Bind("Authentication", options))
+    .AddCookie(options => configuration.Bind(CookieAuthenticationDefaults.AuthenticationScheme, options))
+    .AddOpenIdConnect(options =>
+    {
+        configuration.Bind(OpenIdConnectDefaults.AuthenticationScheme, options);
+
+        // MapInboundClaims is false, so claims keep their original short names.
+        // Point Identity.Name at the "name" claim instead of the default SOAP URI,
+        // otherwise User.Identity.Name comes back empty.
+        options.TokenValidationParameters.NameClaimType = "name";
+    });
+
+builder.Services.AddAuthorization();
+
+// Makes the signed-in user available to components via AuthorizeView / AuthenticationState.
+builder.Services.AddCascadingAuthenticationState();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error", createScopeForErrors: true);
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseAntiforgery();
+
+// Sign-in and sign-out run on the plain HTTP pipeline, never inside an interactive circuit.
+// Writing the auth cookie and issuing the OIDC redirect both need the HTTP response, which
+// has already started once a Blazor Server component is interactive.
+app.MapGet("/auth/login", (string? returnUrl) =>
+    Results.Challenge(
+        new() { RedirectUri = returnUrl ?? "/" },
+        [OpenIdConnectDefaults.AuthenticationScheme]));
+
+// Kept as GET for brevity in this sample. In production trigger sign-out from a POST form
+// that carries an antiforgery token, so a stray GET cannot log the user out.
+app.MapGet("/auth/logout", () =>
+    Results.SignOut(
+        new() { RedirectUri = "/" },
+        [CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme]));
+
+app.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
+
+app.Run();

--- a/BlazorSample/Properties/launchSettings.json
+++ b/BlazorSample/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5005",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/BlazorSample/appsettings.Development.json
+++ b/BlazorSample/appsettings.Development.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "Authentication": {
+    "DefaultScheme": "Cookies",
+    "DefaultChallengeScheme": "OpenIdConnect"
+  },
+  "OpenIdConnect": {
+    "Authority": "https://localhost:5001",
+    "ClientId": "blazor_sample",
+    "ClientSecret": "secret"
+  }
+}

--- a/BlazorSample/appsettings.json
+++ b/BlazorSample/appsettings.json
@@ -1,0 +1,25 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Authentication": {
+    "DefaultScheme": "Cookies",
+    "DefaultChallengeScheme": "OpenIdConnect",
+    "SignOutScheme": "OpenIdConnect"
+  },
+  "OpenIdConnect": {
+    "SignInScheme": "Cookies",
+    "SignOutScheme": "Cookies",
+    "SaveTokens": true,
+    "Scope": [ "openid", "profile", "email" ],
+    "MapInboundClaims": false,
+    "ResponseType": "code",
+    "ResponseMode": "query",
+    "UsePkce": true,
+    "GetClaimsFromUserInfoEndpoint": true
+  }
+}

--- a/GettingStarted.slnx
+++ b/GettingStarted.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Project Path="ApiSample/ApiSample.csproj" />
   <Project Path="BffSample/BffSample.csproj" />
+  <Project Path="BlazorSample/BlazorSample.csproj" />
   <Project Path="OpenIDProviderApp/OpenIDProviderApp.csproj" />
   <Project Path="TestClientApp/TestClientApp.csproj" />
 </Solution>

--- a/OpenIDProviderApp/OpenIDProviderApp.csproj
+++ b/OpenIDProviderApp/OpenIDProviderApp.csproj
@@ -5,6 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="Abblix.Oidc.Server.Mvc" Version="2.2" />
+	<PackageReference Include="Abblix.Oidc.Server.Mvc" Version="2.3" />
   </ItemGroup>
 </Project>

--- a/OpenIDProviderApp/Program.cs
+++ b/OpenIDProviderApp/Program.cs
@@ -51,6 +51,14 @@ builder.Services.AddOidcServices(options =>
             PkceRequired = true,
             RedirectUris = [new Uri("https://localhost:5003/signin-oidc", UriKind.Absolute)],
             PostLogoutRedirectUris = [new Uri("https://localhost:5003/signout-callback-oidc", UriKind.Absolute)],
+        },
+        new ClientInfo("blazor_sample") {
+            ClientSecrets = [new ClientSecret { Sha512Hash = SHA512.HashData(Encoding.UTF8.GetBytes("secret")) }],
+            TokenEndpointAuthMethod = ClientAuthenticationMethods.ClientSecretPost,
+            AllowedGrantTypes = [GrantTypes.AuthorizationCode],
+            PkceRequired = true,
+            RedirectUris = [new Uri("https://localhost:5005/signin-oidc", UriKind.Absolute)],
+            PostLogoutRedirectUris = [new Uri("https://localhost:5005/signout-callback-oidc", UriKind.Absolute)],
         }
     ];
     options.LoginUri = new Uri("/Auth/Login", UriKind.Relative);

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ The `TestClientApp` functions as the Relying Party, acting as a client that depe
 - **BffSample**  
 The `BffSample` implements the Backend-For-Frontend (BFF) architectural pattern to improve the security and manageability of interactions between a Single Page Application (SPA) and its backend services. The BFF acts as an intermediary, handling authentication and session management on behalf of the SPA, thereby reducing the surface area for attacks and simplifying client-side code. This sample is designed to showcase how to effectively apply the BFF pattern in a .NET environment, leveraging modern security practices and enhancing the overall security posture of web applications.
 
+- **BlazorSample**  
+The `BlazorSample` is a Blazor Web App (interactive Server render mode) acting as an OpenID Connect client of the `OpenIDProviderApp`. It shows the pattern that keeps Blazor and OIDC working together: the pages are rendered by Blazor, but sign-in and sign-out run on plain HTTP endpoints rather than inside an interactive circuit, because writing the authentication cookie and issuing the OIDC redirect both need the HTTP response. The sample uses `Microsoft.AspNetCore.Authentication.OpenIdConnect` with cookie sessions, the authorization code flow and PKCE.
+
 - **ApiSample**  
 The `ApiSample` demonstrates how to build a secure backend API that works in conjunction with an OpenID Connect provider to authenticate and authorize client requests. This sample illustrates the integration of security protocols like OAuth 2.0 and OpenID Connect into API development, ensuring that only authenticated and authorized users can access protected resources. The `ApiSample` serves as a practical guide for implementing secure APIs that comply with modern authentication standards, providing a robust foundation for securing backend services in a distributed web application architecture.
 


### PR DESCRIPTION
## What's inside

**Update Abblix packages to v2.3** — all samples now build against the released `Abblix.OIDC.Server` 2.3 packages.

**Add BlazorSample** — a Blazor Web App (interactive Server render mode) acting as an OpenID Connect client of `OpenIDProviderApp`:

- `Microsoft.AspNetCore.Authentication.OpenIdConnect` with cookie sessions, authorization code flow and PKCE
- Sign-in and sign-out run on plain HTTP endpoints rather than inside an interactive circuit, because writing the authentication cookie and issuing the OIDC redirect both need the HTTP response
- Registered in `GettingStarted.slnx`, as the `blazor_sample` client in `OpenIDProviderApp` (redirect URIs on port 5005), and described in the README

## Verification

- `dotnet build BlazorSample/BlazorSample.csproj` — 0 warnings, 0 errors
- Sample was previously verified end-to-end against the discovery fix that shipped in 2.3
