### PR TITLE
Raise the Identity password-hash work factor to OWASP guidance via appsettings

### DIFF
--- a/AspNetIdentitySample/Program.cs
+++ b/AspNetIdentitySample/Program.cs
@@ -33,6 +33,11 @@ builder.Services
     .AddEntityFrameworkStores<AppDbContext>()
     .AddSignInManager();
 
+// Password-hashing work factor: Identity's default hasher here is PBKDF2-HMAC-SHA512. Bind
+// IterationCount from appsettings.json so it can be raised to meet current OWASP guidance for that
+// algorithm without a recompile.
+builder.Services.Configure<PasswordHasherOptions>(builder.Configuration.GetSection("PasswordHasher"));
+
 // The library ships no IUserInfoProvider: this registration is mandatory, not optional.
 builder.Services.AddScoped<IUserInfoProvider, IdentityUserInfoProvider>();
 

--- a/AspNetIdentitySample/appsettings.json
+++ b/AspNetIdentitySample/appsettings.json
@@ -3,6 +3,9 @@
     "Users": "Data Source=users.db",
     "OidcStore": "Data Source=oidc.db"
   },
+  "PasswordHasher": {
+    "IterationCount": 220000
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
The sample relied on Identity's default PBKDF2 iteration count. Binds `IterationCount` from `appsettings.json` and sets it to the current OWASP figure for the default hasher's algorithm: the .NET 10 default is PBKDF2-HMAC-SHA512, so 220,000 iterations.

Verified by decoding the seeded user's stored PasswordHash (v3 format): PRF = HMAC-SHA512, iteration count = 220,000.