### PR TITLE
Use form_post response mode in the BFF sample

### DIFF
--- a/BffSample/appsettings.json
+++ b/BffSample/appsettings.json
@@ -18,7 +18,9 @@
       "Scope": ["openid", "profile", "email", "weather"],
       "MapInboundClaims": false,
       "ResponseType": "code",
-      "ResponseMode": "query",
+      // form_post returns the authorization code in an auto-submitting POST to the backend,
+      // so it never lands in the browser URL, history, or Referer the way "query" would.
+      "ResponseMode": "form_post",
       "UsePkce": true,
       "GetClaimsFromUserInfoEndpoint": true
   },


### PR DESCRIPTION
The provider now returns the authorization code in an auto-submitting POST to the backend's signin-oidc endpoint instead of the query string, so the code never lands in the browser URL, history, or Referer. Microsoft's OpenID Connect middleware ships SameSite=None correlation cookies by default, so the cross-site POST callback completes with no other change.
