### PR TITLE
fix(ci): the actionlint install verifies the archive checksum

### DIFF
--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -56,6 +56,10 @@ jobs:
       contents: read
     env:
       ACTIONLINT_VERSION: '1.7.10'
+      # Сверка обязательна: без неё шаг доверяет тому, что вернёт сеть, и исполняет это с
+      # правами задания. Обновляя версию, возьмите сумму из actionlint_<версия>_checksums.txt
+      # того же релиза.
+      ACTIONLINT_SHA256: 'f4c76b71db5755a713e6055cbb0857ed07e103e028bda117817660ebadb4386f'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -66,6 +70,7 @@ jobs:
         run: |
           curl -fsSL -o actionlint.tar.gz \
             "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum --check --strict
           tar -xzf actionlint.tar.gz actionlint
           chmod +x actionlint
 


### PR DESCRIPTION
fix(ci): the actionlint install verifies the archive checksum

The step pulled an archive off the network and unpacked and ran it straight away with the job's permissions. The only guarantee was TLS, which says "this is certainly that server" and not "this is certainly that file". A swapped release under the same version number would have passed in silence.

The checksum is now declared next to the version and checked with `sha256sum --check --strict` before anything is unpacked. The step's shell runs with `-e`, so a mismatch fails the step instead of leaving a warning in the log.

The value was taken from the real 1.7.10 release artifact and proven in both directions: the genuine archive is accepted, and the same sum with one character changed is refused.

The same edit went into all seven repositories that carry this step. They were found by the condition ("downloads the actionlint archive") rather than by the places already remembered, and there turned out to be seven of them rather than two.