### PR TITLE
chore(samples): lint frontends with typescript-eslint on TS 7

### DIFF
--- a/AspNetIdentitySample/ClientApp/.oxlintrc.json
+++ b/AspNetIdentitySample/ClientApp/.oxlintrc.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["react", "typescript", "oxc"],
-  "categories": {
-    "correctness": "error"
-  },
-  "ignorePatterns": ["dist", "src/api/schema.d.ts"]
-}

--- a/AspNetIdentitySample/ClientApp/eslint.config.js
+++ b/AspNetIdentitySample/ClientApp/eslint.config.js
@@ -1,0 +1,39 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import react from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+
+// schema.d.ts is generated from openapi.json (`npm run gen:api`), not hand-written - lint skips it.
+export default tseslint.config(
+  { ignores: ['dist', 'src/api/schema.d.ts'] },
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommended,
+      react.configs.flat.recommended,
+      react.configs.flat['jsx-runtime'],
+      reactHooks.configs.flat['recommended-latest'],
+      reactRefresh.configs.vite,
+    ],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+    settings: { react: { version: 'detect' } },
+    // A hook exported beside its provider is idiomatic React, not a Fast Refresh hazard.
+    rules: {
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    },
+  },
+  {
+    files: ['vite.config.ts'],
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.node,
+    },
+  },
+);

--- a/AspNetIdentitySample/ClientApp/package.json
+++ b/AspNetIdentitySample/ClientApp/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
-    "lint": "oxlint",
+    "build": "node ./node_modules/typescript-7/bin/tsc -b && vite build",
+    "lint": "eslint .",
     "gen:api": "npx --yes --package typescript@5.9.2 --package openapi-typescript@7.13.0 openapi-typescript ./openapi.json -o src/api/schema.d.ts"
   },
   "dependencies": {
@@ -14,13 +14,24 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.5",
     "@tailwindcss/vite": "^4.1.14",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
-    "oxlint": "^1.73.0",
+    "eslint": "^9.39.5",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-react-refresh": "^0.5.4",
+    "globals": "^16.5.0",
     "tailwindcss": "^4.1.14",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
+    "typescript-7": "npm:typescript@^7.0.2",
+    "typescript-eslint": "^8.67.0",
     "vite": "^8.1.4"
+  },
+  "overrides": {
+    "postcss": "^8.5.26",
+    "nanoid": "^3.3.18"
   }
 }

--- a/AspNetIdentitySample/ClientApp/src/components/SignIn.tsx
+++ b/AspNetIdentitySample/ClientApp/src/components/SignIn.tsx
@@ -52,7 +52,7 @@ export default function SignIn({ requestUri, onSwitch }: SignInProps) {
       </button>
 
       <p className="text-center text-sm text-slate-500 dark:text-slate-400">
-        Don't have an account?{' '}
+        Don&apos;t have an account?{' '}
         <button type="button" onClick={onSwitch} className="font-medium text-sky-600 hover:text-sky-500 dark:text-sky-400">
           Create one
         </button>

--- a/AspNetIdentitySample/ClientAssets/.oxlintrc.json
+++ b/AspNetIdentitySample/ClientAssets/.oxlintrc.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "oxc"],
-  "categories": {
-    "correctness": "error"
-  }
-}

--- a/AspNetIdentitySample/ClientAssets/eslint.config.js
+++ b/AspNetIdentitySample/ClientAssets/eslint.config.js
@@ -1,0 +1,16 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+// Vendor asset bundler: main.ts only imports Bootstrap, so a plain TypeScript baseline is enough.
+export default tseslint.config(
+  { ignores: ['dist'] },
+  {
+    files: ['**/*.ts'],
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+  },
+);

--- a/AspNetIdentitySample/ClientAssets/package.json
+++ b/AspNetIdentitySample/ClientAssets/package.json
@@ -3,15 +3,23 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc && vite build",
-    "lint": "oxlint"
+    "build": "node ./node_modules/typescript-7/bin/tsc && vite build",
+    "lint": "eslint ."
   },
   "dependencies": {
     "bootstrap": "^5.3.8"
   },
   "devDependencies": {
-    "oxlint": "^1.73.0",
-    "typescript": "^7.0.2",
+    "@eslint/js": "^9.39.5",
+    "eslint": "^9.39.5",
+    "globals": "^16.5.0",
+    "typescript": "^6.0.3",
+    "typescript-7": "npm:typescript@^7.0.2",
+    "typescript-eslint": "^8.67.0",
     "vite": "^8.1.4"
+  },
+  "overrides": {
+    "postcss": "^8.5.26",
+    "nanoid": "^3.3.18"
   }
 }

--- a/BffSample/ClientApp/.oxlintrc.json
+++ b/BffSample/ClientApp/.oxlintrc.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["react", "typescript", "oxc"],
-  "categories": {
-    "correctness": "error"
-  },
-  "ignorePatterns": ["dist"]
-}

--- a/BffSample/ClientApp/eslint.config.js
+++ b/BffSample/ClientApp/eslint.config.js
@@ -1,0 +1,40 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import react from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+
+// React app source runs in the browser; vite.config.ts runs in Node (it reads the dev
+// cert off disk and shells out to `dotnet dev-certs`), so its globals are declared apart.
+export default tseslint.config(
+  { ignores: ['dist'] },
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommended,
+      react.configs.flat.recommended,
+      react.configs.flat['jsx-runtime'],
+      reactHooks.configs.flat['recommended-latest'],
+      reactRefresh.configs.vite,
+    ],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+    settings: { react: { version: 'detect' } },
+    // A hook exported beside its provider is idiomatic React, not a Fast Refresh hazard.
+    rules: {
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    },
+  },
+  {
+    files: ['vite.config.ts'],
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.node,
+    },
+  },
+);

--- a/BffSample/ClientApp/package.json
+++ b/BffSample/ClientApp/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
-    "lint": "oxlint",
+    "build": "node ./node_modules/typescript-7/bin/tsc -b && vite build",
+    "lint": "eslint .",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -14,12 +14,23 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.5",
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
-    "oxlint": "^1.73.0",
-    "typescript": "^7.0.2",
+    "eslint": "^9.39.5",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-react-refresh": "^0.5.4",
+    "globals": "^16.5.0",
+    "typescript": "^6.0.3",
+    "typescript-7": "npm:typescript@^7.0.2",
+    "typescript-eslint": "^8.67.0",
     "vite": "^8.1.4"
+  },
+  "overrides": {
+    "postcss": "^8.5.26",
+    "nanoid": "^3.3.18"
   }
 }

--- a/OpenIDProviderApp/ClientAssets/.oxlintrc.json
+++ b/OpenIDProviderApp/ClientAssets/.oxlintrc.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "oxc"],
-  "categories": {
-    "correctness": "error"
-  }
-}

--- a/OpenIDProviderApp/ClientAssets/eslint.config.js
+++ b/OpenIDProviderApp/ClientAssets/eslint.config.js
@@ -1,0 +1,16 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+// Vendor asset bundler: main.ts only imports Bootstrap, so a plain TypeScript baseline is enough.
+export default tseslint.config(
+  { ignores: ['dist'] },
+  {
+    files: ['**/*.ts'],
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+  },
+);

--- a/OpenIDProviderApp/ClientAssets/package.json
+++ b/OpenIDProviderApp/ClientAssets/package.json
@@ -3,15 +3,23 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc && vite build",
-    "lint": "oxlint"
+    "build": "node ./node_modules/typescript-7/bin/tsc && vite build",
+    "lint": "eslint ."
   },
   "dependencies": {
     "bootstrap": "^5.3.8"
   },
   "devDependencies": {
-    "oxlint": "^1.73.0",
-    "typescript": "^7.0.2",
+    "@eslint/js": "^9.39.5",
+    "eslint": "^9.39.5",
+    "globals": "^16.5.0",
+    "typescript": "^6.0.3",
+    "typescript-7": "npm:typescript@^7.0.2",
+    "typescript-eslint": "^8.67.0",
     "vite": "^8.1.4"
+  },
+  "overrides": {
+    "postcss": "^8.5.26",
+    "nanoid": "^3.3.18"
   }
 }

--- a/TestClientApp/ClientAssets/.oxlintrc.json
+++ b/TestClientApp/ClientAssets/.oxlintrc.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "oxc"],
-  "categories": {
-    "correctness": "error"
-  }
-}

--- a/TestClientApp/ClientAssets/eslint.config.js
+++ b/TestClientApp/ClientAssets/eslint.config.js
@@ -1,0 +1,16 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+// Vendor asset bundler: main.ts only imports Bootstrap, so a plain TypeScript baseline is enough.
+export default tseslint.config(
+  { ignores: ['dist'] },
+  {
+    files: ['**/*.ts'],
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+  },
+);

--- a/TestClientApp/ClientAssets/package.json
+++ b/TestClientApp/ClientAssets/package.json
@@ -3,15 +3,23 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc && vite build",
-    "lint": "oxlint"
+    "build": "node ./node_modules/typescript-7/bin/tsc && vite build",
+    "lint": "eslint ."
   },
   "dependencies": {
     "bootstrap": "^5.3.8"
   },
   "devDependencies": {
-    "oxlint": "^1.73.0",
-    "typescript": "^7.0.2",
+    "@eslint/js": "^9.39.5",
+    "eslint": "^9.39.5",
+    "globals": "^16.5.0",
+    "typescript": "^6.0.3",
+    "typescript-7": "npm:typescript@^7.0.2",
+    "typescript-eslint": "^8.67.0",
     "vite": "^8.1.4"
+  },
+  "overrides": {
+    "postcss": "^8.5.26",
+    "nanoid": "^3.3.18"
   }
 }


### PR DESCRIPTION
Sample frontends move off oxlint onto typescript-eslint, kept working on TypeScript 7 through Microsoft's side-by-side scheme.

## Why

The frontends were linted with oxlint on the premise that TypeScript 7 breaks typescript-eslint and that this is not fixable via npm config. That premise no longer holds. Pinning `typescript` to the 6.0.x JS-compiler line for the linter, while compiling through a `typescript-7` npm alias, keeps the full typescript-eslint plugin set working on TS 7.

## What

- Each frontend keeps `typescript` on `^6.0.3` (the compiler API typescript-eslint reads) and adds `typescript-7` (`npm:typescript@^7.0.2`); `build`/`typecheck` run the alias `tsc`.
- `oxlint` and `.oxlintrc.json` are dropped. Each project gets a flat `eslint.config.js` carrying only the plugins its code needs:
  - React apps (`*/ClientApp`): `@eslint/js` + typescript-eslint + eslint-plugin-react + react-hooks + react-refresh. BffSample also gets a Node-globals block for its `vite.config.ts`, which reads the dev cert and shells out to `dotnet dev-certs`.
  - Vendor asset bundlers (`*/ClientAssets`): the TypeScript baseline only; `main.ts` just imports Bootstrap.
- One real finding the stricter linter surfaced is fixed: an unescaped apostrophe in `SignIn.tsx` (`react/no-unescaped-entities`).
- `postcss` and `nanoid` (transitive through vite) are pinned past their advisories via `overrides`.

## Verification

For every one of the five projects, `npm run lint` and `npm run build` are green and `npm audit` reports 0 vulnerabilities.
