### PR TITLE
License the samples under MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+MIT License
+
+Copyright (c) 2024-2026 Abblix LLP
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+The MIT licence above covers the sample code in this repository. Abblix OIDC
+Server itself is a separate product under its own licence, consumed here as a
+NuGet package and not redistributed in source form. Its terms are at
+https://www.abblix.com/license.

--- a/OpenIDProviderApp/Controllers/AuthController.cs
+++ b/OpenIDProviderApp/Controllers/AuthController.cs
@@ -1,26 +1,4 @@
-// Abblix OIDC Server Library
-// Copyright (c) Abblix LLP. All rights reserved.
-//
-// DISCLAIMER: This software is provided 'as-is', without any express or implied
-// warranty. Use at your own risk. Abblix LLP is not liable for any damages
-// arising from the use of this software.
-//
-// LICENSE RESTRICTIONS: This code may not be modified, copied, or redistributed
-// in any form outside of the official GitHub repository at:
-// https://github.com/Abblix/OIDC.Server. All development and modifications
-// must occur within the official repository and are managed solely by Abblix LLP.
-//
-// Unauthorized use, modification, or distribution of this software is strictly
-// prohibited and may be subject to legal action.
-//
-// For full licensing terms, please visit:
-//
-// https://oidc.abblix.com/license
-//
-// CONTACT: For license inquiries or permissions, contact Abblix LLP at
-// info@abblix.com
-
-using Abblix.Oidc.Server.Features.RandomGenerators;
+﻿using Abblix.Oidc.Server.Features.RandomGenerators;
 using Abblix.Oidc.Server.Features.UserAuthentication;
 using Abblix.Oidc.Server.Model;
 using Abblix.Oidc.Server.Mvc;

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![OS](https://img.shields.io/badge/OS-linux%2C%20windows%2C%20macOS-0078D4)](https://docs.abblix.com/docs/technical-requirements)
 [![CPU](https://img.shields.io/badge/CPU-x86%2C%20x64%2C%20ARM%2C%20ARM64-FF8C00)](https://docs.abblix.com/docs/technical-requirements)
 [![GitHub last commit](https://img.shields.io/github/last-commit/Abblix/Oidc.Server.GettingStarted)](#)
-[![license: CC BY 4.0](https://img.shields.io/badge/license-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
+[![license: MIT](https://img.shields.io/badge/license-MIT-brightgreen.svg)](LICENSE)
 
 
 ⭐ Star us on GitHub - it motivates us a lot!
@@ -94,7 +94,9 @@ After this, `git commit` automatically runs `actionlint` and a custom secrets-in
 
 ## 📃 License
 
-This project is licensed under the Creative Commons Attribution 4.0 International License. You can review the full license text at the following link: [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/).
+The sample code in this repository is licensed under the MIT License - see [LICENSE](LICENSE). Copy it into your own project, change it, ship it.
+
+Abblix OIDC Server itself is a separate product under its own licence, consumed here as a NuGet package and not redistributed in source form. Its terms are at [abblix.com/license](https://www.abblix.com/license).
 
 ## 🔗 Key Contacts & Resources
 


### PR DESCRIPTION
The repository claimed CC BY 4.0 in its readme and carried no licence file, so GitHub reported none and the repository card read as all rights reserved. Two problems in one: the claim and the machine-readable state disagreed, and the claimed licence was the wrong kind.

Creative Commons ask that their licences not be applied to software, and the reason bites here. These projects exist to be copied into somebody's application. CC BY says nothing about patents or about the distinction between source and object code, and it attaches an attribution condition to every distribution of the work - including a compiled product. A reviewing lawyer meeting that on a vendor sample can reasonably stop the copy, which defeats the only purpose the repository has.

MIT states what the samples are for: take it, change it, ship it, keep the notice.

### Scope of the licence

MIT covers the sample code here and nothing else. Abblix OIDC Server is consumed as a NuGet package (`PackageReference Abblix.Oidc.Server.Mvc`), is not redistributed in source form, and keeps its own licence. Both the licence file and the readme say so, so a reader cannot mistake one for the other.

### One header that contradicted it

`OpenIDProviderApp/Controllers/AuthController.cs` carried the library's own file header, copied along with the code it was adapted from: "This code may not be modified, copied, or redistributed in any form outside of the official GitHub repository." That forbids exactly what this repository invites, and it was the only file in 43 sources carrying it. Removed, and the project still builds.

Closes the side task in Abblix/Account#9.
