### PR TITLE
Keep LICENSE to the text a licence detector recognises

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,10 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-The MIT licence above covers the sample code in this repository. Abblix OIDC
-Server itself is a separate product under its own licence, consumed here as a
-NuGet package and not redistributed in source form. Its terms are at
-https://www.abblix.com/license.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+The MIT licence in LICENSE covers the sample code in this repository.
+
+Abblix OIDC Server is a separate product under its own licence. The samples
+consume it as a NuGet package and do not redistribute it in source form, so
+copying a sample gives you no rights to the library itself. Its terms are at
+https://www.abblix.com/license.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ After this, `git commit` automatically runs `actionlint` and a custom secrets-in
 
 ## 📃 License
 
-The sample code in this repository is licensed under the MIT License - see [LICENSE](LICENSE). Copy it into your own project, change it, ship it.
+The sample code in this repository is licensed under the MIT License - see [LICENSE](LICENSE). Copy it into your own project, change it, ship it. The boundary between this code and the product it demonstrates is spelled out in [NOTICE](NOTICE).
 
 Abblix OIDC Server itself is a separate product under its own licence, consumed here as a NuGet package and not redistributed in source form. Its terms are at [abblix.com/license](https://www.abblix.com/license).
 


### PR DESCRIPTION
GitHub's licence API answered `NOASSERTION / Other` for the file added in #31, so the repository card still read as having no licence - the exact state that PR set out to fix. The cause is the scope paragraph appended under the MIT text: a detector matches the file against the canonical licence and a substantial addition pushes it past the matching threshold.

The MIT text now stands alone. The boundary it was there to state - these samples are MIT, the library they consume keeps its own licence and is not redistributed in source form - moves to `NOTICE`, which the readme links.

Verification is the card itself: after merge, `gh api repos/Abblix/Oidc.Server.GettingStarted/license` should answer `MIT` rather than `NOASSERTION`.