### PR TITLE
Put the actionlint checksum comment in English

### DIFF
--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -56,9 +56,9 @@ jobs:
       contents: read
     env:
       ACTIONLINT_VERSION: '1.7.10'
-      # Сверка обязательна: без неё шаг доверяет тому, что вернёт сеть, и исполняет это с
-      # правами задания. Обновляя версию, возьмите сумму из actionlint_<версия>_checksums.txt
-      # того же релиза.
+      # The checksum is mandatory: without it the step trusts whatever the network returns and runs
+      # it with the job's privileges. When bumping the version, take the sum from
+      # actionlint_<version>_checksums.txt of that same release.
       ACTIONLINT_SHA256: 'f4c76b71db5755a713e6055cbb0857ed07e103e028bda117817660ebadb4386f'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
This repository is public, so its comments are read by people outside the team. The note explaining why the checksum is mandatory was in Russian, which made it useless to most of them.

Only the comment changes: the checksum value and every step stay as they are, and actionlint is clean.
